### PR TITLE
fix: Rewrite empty package specification for stack.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -29,7 +29,8 @@ resolver:
 #   subdirs:
 #   - auto-update
 #   - wai
-packages: []
+packages:
+  - .
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:


### PR DESCRIPTION
This allows stack to compile the package.
Note: I'm not particularly sure about this change,
and it comes from tinkering rather than from
deep understanding.

This starts to fix this issue:
https://github.com/Hazelfire/pedant/issues/2